### PR TITLE
Fix flash write for Atmega328p when using ISP interface

### DIFF
--- a/pymcuprog/deviceinfo/devices/atmega328p.py
+++ b/pymcuprog/deviceinfo/devices/atmega328p.py
@@ -16,6 +16,7 @@ DEVICE_INFO = {
     'flash_read_size_bytes': 0x80,
     'flash_chiperase_effect': ChiperaseEffect.ALWAYS_ERASED,
     'flash_isolated_erase': False,
+    'flash_page_write_max_time_out_ms': 4.7,
 
     # signatures
     'signatures_address_byte': 0,

--- a/pymcuprog/nvmspi.py
+++ b/pymcuprog/nvmspi.py
@@ -2,6 +2,7 @@
 SPI NVM implementation
 NB: This is a stub - not all features are implemented.
 """
+import time
 from pyedbglib.protocols.avrispprotocol import AvrIspProtocol
 
 from . import utils
@@ -63,6 +64,7 @@ class NvmAccessProviderCmsisDapSpi(NvmAccessProviderCmsisDapAvr):
                                                        memory_info[DeviceMemoryInfoKeys.WRITE_SIZE])
         if memory_info[DeviceMemoryInfoKeys.NAME] == MemoryNames.FLASH:
             write_chunk_size = memory_info[DeviceMemoryInfoKeys.PAGE_SIZE]
+            write_page_delay_ms = self.device_info.get('flash_page_write_max_time_out_ms', 0)
             while data_aligned:
                 if len(data_aligned) < write_chunk_size:
                     write_chunk_size = len(data_aligned)
@@ -71,6 +73,8 @@ class NvmAccessProviderCmsisDapSpi(NvmAccessProviderCmsisDapAvr):
                 self.isp.write_flash_page(offset_aligned, chunk)
                 offset_aligned += write_chunk_size
                 data_aligned = data_aligned[write_chunk_size:]
+                # Give flash page write operation time to be accomplished by the device
+                time.sleep(write_page_delay_ms/1000.0)
         elif memory_info[DeviceMemoryInfoKeys.NAME] == MemoryNames.EEPROM:
             write_chunk_size = memory_info[DeviceMemoryInfoKeys.PAGE_SIZE]
             while data_aligned:


### PR DESCRIPTION
This MR is about adding delay between consecutive flash page write operations for the Atmega328p devices when using the ISP protocol.
This fixes the problem of corrupted writes that occurs when writing multiple flash pages consecutively.